### PR TITLE
Contributing guideline and function documentation

### DIFF
--- a/R/transform.R
+++ b/R/transform.R
@@ -4,7 +4,7 @@
 #'
 #' @param population tbl with grouping (metadata) and observation variables.
 #' @param variables character vector specifying observation variables.
-#' @param operation optional character string specifying method for transform. Currently, only \code{"generalized_log"} (default) is implemented.
+#' @param operation optional character string specifying method for transform. This must be one of the strings \code{"generalized_log"} (default), \code{"whiten"}.
 #' @param ... arguments passed to transformation operation.
 #'
 #' @return transformed data of the same class as \code{population}.

--- a/README.md
+++ b/README.md
@@ -39,3 +39,8 @@ Example
 -------
 
 See `vignette("cytominer-pipeline")` for basic example of using cytominer to analyze a morphological profiling dataset.
+
+Contributing
+------------
+
+Read more about the contributing process [on our wiki](https://github.com/cytomining/cytominer/wiki/Contributing).


### PR DESCRIPTION
Resolves #70

I've added a [wiki page on contributing](https://github.com/cytomining/cytominer/wiki/Contributing) to `cytominer`. It also includes a high-level overview of the function standardization used by `aggregate`, `normalize`, etc. 

What do you think? Is anything unclear? @shntnu @cells2numbers 