### PR TITLE
dplyr 1.0.0 compatibility updates

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,5 @@
 ^LICENSE.md$
 ^CONTRIBUTING.md$
 ^CRAN-RELEASE$
+^packrat/
+^\.Rprofile$

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .Rhistory
 .RData
 inst/doc
+packrat/lib*/
+packrat
+.Rprofile

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,4 +46,4 @@ Suggests:
 VignetteBuilder: knitr
 URL: https://github.com/cytomining/cytominer
 BugReports: https://github.com/cytomining/cytominer/issues
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.0

--- a/R/drop_na_rows.R
+++ b/R/drop_na_rows.R
@@ -32,7 +32,6 @@ drop_na_rows <- function(population, variables) {
       tidyr::pivot_wider(names_from = "name", values_from = "value") %>%
       dplyr::select(-rowid) %>%
       dplyr::select(names(population))
-
   } else {
 
     # Coalesce() must have at least 2 arguments.

--- a/R/drop_na_rows.R
+++ b/R/drop_na_rows.R
@@ -1,12 +1,12 @@
-utils::globalVariables(c("key", "value", "rowname_temp", "coalesce"))
-#' Drop rows that are \code{NA} in all variables.
+utils::globalVariables(c("key", "value", "rowname_temp", "rowid", "coalesce"))
+#' Drop rows that are \code{NA} in all specified variables.
 #'
-#' \code{drop_na_rows} drops rows that are \code{NA} in all variables.
+#' \code{drop_na_rows} drops rows that are \code{NA} in all specified variables.
 #'
 #' @param population tbl with grouping (metadata) and observation variables.
 #' @param variables character vector specifying observation variables.
 #'
-#' @return \code{population} without rows that have \code{NA} in all variables.
+#' @return \code{population} without rows that have \code{NA} in all specified variables.
 #'
 #' @examples
 #' population <- tibble::tibble(
@@ -26,11 +26,13 @@ utils::globalVariables(c("key", "value", "rowname_temp", "coalesce"))
 drop_na_rows <- function(population, variables) {
   if (is.data.frame(population)) {
     population %>%
-      tibble::rownames_to_column(., var = "rowname_temp") %>%
-      tidyr::gather(key, value, variables) %>%
+      tibble::rowid_to_column() %>%
+      tidyr::pivot_longer(variables) %>%
       dplyr::filter(!is.na(value)) %>%
-      tidyr::spread(key, value) %>%
-      dplyr::select(-rowname_temp)
+      tidyr::pivot_wider(names_from = "name", values_from = "value") %>%
+      dplyr::select(-rowid) %>%
+      dplyr::select(names(population))
+
   } else {
 
     # Coalesce() must have at least 2 arguments.

--- a/R/extract_subpopulations.R
+++ b/R/extract_subpopulations.R
@@ -70,7 +70,7 @@ extract_subpopulations <-
         as.matrix())[1, 2]
     }
 
-    data %<>% dplyr::mutate(cluster_id = kmeans_output$cluster)
+    data %<>% dplyr::mutate(cluster_id = unname(kmeans_output$cluster))
     data %<>%
       dplyr::bind_cols(
         purrr::map_df(

--- a/docs/404.html
+++ b/docs/404.html
@@ -145,7 +145,7 @@ Content not found. Please use links in the navbar.
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.0.</p>
 </div>
 
       </footer>

--- a/docs/CONTRIBUTING.html
+++ b/docs/CONTRIBUTING.html
@@ -296,7 +296,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.0.</p>
 </div>
 
       </footer>

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -148,7 +148,7 @@ ORGANIZATION: Broad Institute, Inc.
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.0.</p>
 </div>
 
       </footer>

--- a/docs/LICENSE.html
+++ b/docs/LICENSE.html
@@ -155,7 +155,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.0.</p>
 </div>
 
       </footer>

--- a/docs/articles/cytominer-pipeline.html
+++ b/docs/articles/cytominer-pipeline.html
@@ -85,7 +85,7 @@
       <h1 data-toc-skip>Introduction to cytominer</h1>
                         <h4 class="author">Allen Goodman and Shantanu Singh</h4>
             
-            <h4 class="date">2020-04-28</h4>
+            <h4 class="date">2020-05-08</h4>
       
       <small class="dont-index">Source: <a href="https://github.com/cytomining/cytominer/blob/master/vignettes/cytominer-pipeline.Rmd"><code>vignettes/cytominer-pipeline.Rmd</code></a></small>
       <div class="hidden name"><code>cytominer-pipeline.Rmd</code></div>
@@ -117,7 +117,7 @@
 <div class="sourceCode" id="cb3"><html><body><pre class="r"><span class="no">ext_metadata</span> <span class="kw">&lt;-</span>
   <span class="kw pkg">readr</span><span class="kw ns">::</span><span class="fu"><a href="https://readr.tidyverse.org/reference/read_delim.html">read_csv</a></span>(<span class="fu"><a href="https://rdrr.io/r/base/system.file.html">system.file</a></span>(<span class="st">"extdata"</span>, <span class="st">"metadata.csv"</span>,
                               <span class="kw">package</span> <span class="kw">=</span> <span class="st">"cytominer"</span>)) <span class="kw">%&gt;%</span>
-  <span class="kw pkg">dplyr</span><span class="kw ns">::</span><span class="fu"><a href="https://dplyr.tidyverse.org/reference/select.html">rename</a></span>(<span class="kw">g_well</span> <span class="kw">=</span> <span class="no">Well</span>)</pre></body></html></div>
+  <span class="kw pkg">dplyr</span><span class="kw ns">::</span><span class="fu"><a href="https://dplyr.tidyverse.org/reference/rename.html">rename</a></span>(<span class="kw">g_well</span> <span class="kw">=</span> <span class="no">Well</span>)</pre></body></html></div>
 <pre><code>## Parsed with column specification:
 ## cols(
 ##   Well = col_character(),
@@ -134,7 +134,7 @@
   <span class="kw pkg">dplyr</span><span class="kw ns">::</span><span class="fu"><a href="https://dplyr.tidyverse.org/reference/filter.html">filter</a></span>(<span class="no">g_well</span> <span class="kw">%in%</span> <span class="fu"><a href="https://rdrr.io/r/base/c.html">c</a></span>(<span class="st">"A01"</span>, <span class="st">"A02"</span>, <span class="st">"A10"</span>, <span class="st">"A11"</span>))</pre></body></html></div>
 <p>How many rows does this table have?</p>
 <div class="sourceCode" id="cb8"><html><body><pre class="r"><span class="no">measurements</span> <span class="kw">%&gt;%</span>
-  <span class="kw pkg">dplyr</span><span class="kw ns">::</span><span class="fu"><a href="https://dplyr.tidyverse.org/reference/tally.html">tally</a></span>() <span class="kw">%&gt;%</span>
+  <span class="kw pkg">dplyr</span><span class="kw ns">::</span><span class="fu"><a href="https://dplyr.tidyverse.org/reference/count.html">tally</a></span>() <span class="kw">%&gt;%</span>
   <span class="kw pkg">knitr</span><span class="kw ns">::</span><span class="fu"><a href="https://rdrr.io/pkg/knitr/man/kable.html">kable</a></span>()</pre></body></html></div>
 <table class="table">
 <thead><tr class="header">
@@ -193,7 +193,7 @@
     <span class="kw">strata</span> <span class="kw">=</span>  <span class="fu"><a href="https://rdrr.io/r/base/c.html">c</a></span>(<span class="st">"g_plate"</span>, <span class="st">"g_pattern"</span>, <span class="st">"g_channel"</span>),
     <span class="kw">sample</span> <span class="kw">=</span>
       <span class="no">na_rows_removed</span> <span class="kw">%&gt;%</span>
-      <span class="kw pkg">dplyr</span><span class="kw ns">::</span><span class="fu"><a href="https://dplyr.tidyverse.org/reference/join.html">inner_join</a></span>(
+      <span class="kw pkg">dplyr</span><span class="kw ns">::</span><span class="fu"><a href="https://dplyr.tidyverse.org/reference/mutate-joins.html">inner_join</a></span>(
         <span class="no">ext_metadata</span> <span class="kw">%&gt;%</span>
           <span class="kw pkg">dplyr</span><span class="kw ns">::</span><span class="fu"><a href="https://dplyr.tidyverse.org/reference/filter.html">filter</a></span>(<span class="no">Type</span> <span class="kw">==</span> <span class="st">"ctrl"</span>) <span class="kw">%&gt;%</span>
           <span class="kw pkg">dplyr</span><span class="kw ns">::</span><span class="fu"><a href="https://dplyr.tidyverse.org/reference/select.html">select</a></span>(<span class="no">g_well</span>)
@@ -335,7 +335,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.0.</p>
 </div>
 
       </footer>

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -144,7 +144,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.0.</p>
 </div>
 
       </footer>

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -160,7 +160,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.0.</p>
 </div>
 
       </footer>

--- a/docs/index.html
+++ b/docs/index.html
@@ -174,7 +174,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.0.</p>
 </div>
 
       </footer>

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -183,7 +183,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.0.</p>
 </div>
 
       </footer>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -1,7 +1,7 @@
 pandoc: 2.9.2.1
-pkgdown: 1.5.1
+pkgdown: 1.5.0
 pkgdown_sha: ~
 articles:
   cytominer-pipeline: cytominer-pipeline.html
-last_built: 2020-04-29T02:38Z
+last_built: 2020-05-08T23:08Z
 

--- a/docs/reference/aggregate.html
+++ b/docs/reference/aggregate.html
@@ -132,8 +132,14 @@
     <p><code>aggregate</code> aggregates data based on the specified aggregation method.</p>
     </div>
 
-    <pre class="usage"><span class='fu'>aggregate</span>(<span class='no'>population</span>, <span class='no'>variables</span>, <span class='no'>strata</span>, <span class='kw'>operation</span> <span class='kw'>=</span> <span class='st'>"mean"</span>,
-  <span class='kw'>univariate</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>, <span class='no'>...</span>)</pre>
+    <pre class="usage"><span class='fu'>aggregate</span>(
+  <span class='no'>population</span>,
+  <span class='no'>variables</span>,
+  <span class='no'>strata</span>,
+  <span class='kw'>operation</span> <span class='kw'>=</span> <span class='st'>"mean"</span>,
+  <span class='kw'>univariate</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>,
+  <span class='no'>...</span>
+)</pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
@@ -205,7 +211,7 @@ univariate or multivariate.</p></td>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.0.</p>
 </div>
 
       </footer>

--- a/docs/reference/correlation_threshold.html
+++ b/docs/reference/correlation_threshold.html
@@ -132,8 +132,7 @@
     <p><code>correlation_threshold</code> returns list of variables such that no two variables have a correlation greater than a specified threshold.</p>
     </div>
 
-    <pre class="usage"><span class='fu'>correlation_threshold</span>(<span class='no'>variables</span>, <span class='no'>sample</span>, <span class='kw'>cutoff</span> <span class='kw'>=</span> <span class='fl'>0.9</span>,
-  <span class='kw'>method</span> <span class='kw'>=</span> <span class='st'>"pearson"</span>)</pre>
+    <pre class="usage"><span class='fu'>correlation_threshold</span>(<span class='no'>variables</span>, <span class='no'>sample</span>, <span class='kw'>cutoff</span> <span class='kw'>=</span> <span class='fl'>0.9</span>, <span class='kw'>method</span> <span class='kw'>=</span> <span class='st'>"pearson"</span>)</pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
@@ -204,7 +203,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.0.</p>
 </div>
 
       </footer>

--- a/docs/reference/count_na_rows.html
+++ b/docs/reference/count_na_rows.html
@@ -180,7 +180,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.0.</p>
 </div>
 
       </footer>

--- a/docs/reference/covariance.html
+++ b/docs/reference/covariance.html
@@ -178,7 +178,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.0.</p>
 </div>
 
       </footer>

--- a/docs/reference/drop_na_columns.html
+++ b/docs/reference/drop_na_columns.html
@@ -182,7 +182,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.0.</p>
 </div>
 
       </footer>

--- a/docs/reference/drop_na_rows.html
+++ b/docs/reference/drop_na_rows.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Drop rows that are <code>NA</code> in all variables. — drop_na_rows • cytominer</title>
+<title>Drop rows that are <code>NA</code> in all specified variables. — drop_na_rows • cytominer</title>
 
 
 <!-- jquery -->
@@ -39,8 +39,8 @@
 
 
 
-<meta property="og:title" content="Drop rows that are <code>NA</code> in all variables. — drop_na_rows" />
-<meta property="og:description" content="drop_na_rows drops rows that are NA in all variables." />
+<meta property="og:title" content="Drop rows that are <code>NA</code> in all specified variables. — drop_na_rows" />
+<meta property="og:description" content="drop_na_rows drops rows that are NA in all specified variables." />
 
 
 
@@ -123,13 +123,13 @@
 <div class="row">
   <div class="col-md-9 contents">
     <div class="page-header">
-    <h1>Drop rows that are <code>NA</code> in all variables.</h1>
+    <h1>Drop rows that are <code>NA</code> in all specified variables.</h1>
     <small class="dont-index">Source: <a href='https://github.com/cytomining/cytominer/blob/master/R/drop_na_rows.R'><code>R/drop_na_rows.R</code></a></small>
     <div class="hidden name"><code>drop_na_rows.Rd</code></div>
     </div>
 
     <div class="ref-description">
-    <p><code>drop_na_rows</code> drops rows that are <code>NA</code> in all variables.</p>
+    <p><code>drop_na_rows</code> drops rows that are <code>NA</code> in all specified variables.</p>
     </div>
 
     <pre class="usage"><span class='fu'>drop_na_rows</span>(<span class='no'>population</span>, <span class='no'>variables</span>)</pre>
@@ -149,7 +149,7 @@
 
     <h2 class="hasAnchor" id="value"><a class="anchor" href="#value"></a>Value</h2>
 
-    <p><code>population</code> without rows that have <code>NA</code> in all variables.</p>
+    <p><code>population</code> without rows that have <code>NA</code> in all specified variables.</p>
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
     <pre class="examples"><div class='input'><span class='no'>population</span> <span class='kw'>&lt;-</span> <span class='kw pkg'>tibble</span><span class='kw ns'>::</span><span class='fu'><a href='https://tibble.tidyverse.org/reference/tibble.html'>tibble</a></span>(
@@ -187,7 +187,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.0.</p>
 </div>
 
       </footer>

--- a/docs/reference/extract_subpopulations.html
+++ b/docs/reference/extract_subpopulations.html
@@ -229,7 +229,7 @@ the predicted cluster for all input data (<code>population_clusters</code> and
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.0.</p>
 </div>
 
       </footer>

--- a/docs/reference/generalized_log.html
+++ b/docs/reference/generalized_log.html
@@ -183,7 +183,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.0.</p>
 </div>
 
       </footer>

--- a/docs/reference/generate_component_matrix.html
+++ b/docs/reference/generate_component_matrix.html
@@ -8700,7 +8700,7 @@ the elements of the random matrix are drawn from</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.0.</p>
 </div>
 
       </footer>

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -180,7 +180,7 @@
         <td>
           <p><code><a href="drop_na_rows.html">drop_na_rows()</a></code> </p>
         </td>
-        <td><p>Drop rows that are <code>NA</code> in all variables.</p></td>
+        <td><p>Drop rows that are <code>NA</code> in all specified variables.</p></td>
       </tr><tr>
         
         <td>
@@ -272,7 +272,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.0.</p>
 </div>
 
       </footer>

--- a/docs/reference/normalize.html
+++ b/docs/reference/normalize.html
@@ -132,8 +132,14 @@
     <p><code>normalize</code> normalizes observation variables based on the specified normalization method.</p>
     </div>
 
-    <pre class="usage"><span class='fu'>normalize</span>(<span class='no'>population</span>, <span class='no'>variables</span>, <span class='no'>strata</span>, <span class='no'>sample</span>,
-  <span class='kw'>operation</span> <span class='kw'>=</span> <span class='st'>"standardize"</span>, <span class='no'>...</span>)</pre>
+    <pre class="usage"><span class='fu'>normalize</span>(
+  <span class='no'>population</span>,
+  <span class='no'>variables</span>,
+  <span class='no'>strata</span>,
+  <span class='no'>sample</span>,
+  <span class='kw'>operation</span> <span class='kw'>=</span> <span class='st'>"standardize"</span>,
+  <span class='no'>...</span>
+)</pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
@@ -207,7 +213,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.0.</p>
 </div>
 
       </footer>

--- a/docs/reference/replicate_correlation.html
+++ b/docs/reference/replicate_correlation.html
@@ -132,8 +132,15 @@
     <p>`replicate_correlation` measures replicate correlation of variables.</p>
     </div>
 
-    <pre class="usage"><span class='fu'>replicate_correlation</span>(<span class='no'>sample</span>, <span class='no'>variables</span>, <span class='no'>strata</span>, <span class='no'>replicates</span>,
-  <span class='kw'>replicate_by</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>split_by</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>cores</span> <span class='kw'>=</span> <span class='kw'>NULL</span>)</pre>
+    <pre class="usage"><span class='fu'>replicate_correlation</span>(
+  <span class='no'>sample</span>,
+  <span class='no'>variables</span>,
+  <span class='no'>strata</span>,
+  <span class='no'>replicates</span>,
+  <span class='kw'>replicate_by</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
+  <span class='kw'>split_by</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
+  <span class='kw'>cores</span> <span class='kw'>=</span> <span class='kw'>NULL</span>
+)</pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
@@ -216,7 +223,7 @@
   <span class='kw'>cores</span> <span class='kw'>=</span> <span class='fl'>1</span>
 )</div><div class='output co'>#&gt; </span><span style='color: #555555;'># A tibble: 3 x 4</span><span>
 #&gt;   variable median   min   max
-#&gt;   </span><span style='color: #555555;font-style: italic;'>&lt;chr&gt;</span><span>     </span><span style='color: #555555;font-style: italic;'>&lt;dbl&gt;</span><span> </span><span style='color: #555555;font-style: italic;'>&lt;dbl&gt;</span><span> </span><span style='color: #555555;font-style: italic;'>&lt;dbl&gt;</span><span>
+#&gt; </span><span style='color: #555555;'>*</span><span> </span><span style='color: #555555;font-style: italic;'>&lt;chr&gt;</span><span>     </span><span style='color: #555555;font-style: italic;'>&lt;dbl&gt;</span><span> </span><span style='color: #555555;font-style: italic;'>&lt;dbl&gt;</span><span> </span><span style='color: #555555;font-style: italic;'>&lt;dbl&gt;</span><span>
 #&gt; </span><span style='color: #555555;'>1</span><span> x         1.00  1.00  1.00 
 #&gt; </span><span style='color: #555555;'>2</span><span> y         0.996 0.993 0.999
 #&gt; </span><span style='color: #555555;'>3</span><span> z         0.627 0.290 0.964</div></span></pre>
@@ -235,7 +242,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.0.</p>
 </div>
 
       </footer>

--- a/docs/reference/sparse_random_projection.html
+++ b/docs/reference/sparse_random_projection.html
@@ -190,7 +190,7 @@ compute than a Gaussian random projection matrix, while providing similar embedd
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.0.</p>
 </div>
 
       </footer>

--- a/docs/reference/svd_entropy.html
+++ b/docs/reference/svd_entropy.html
@@ -184,7 +184,7 @@ Higher values indicate more information.</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.0.</p>
 </div>
 
       </footer>

--- a/docs/reference/transform.html
+++ b/docs/reference/transform.html
@@ -187,7 +187,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.0.</p>
 </div>
 
       </footer>

--- a/docs/reference/variable_importance.html
+++ b/docs/reference/variable_importance.html
@@ -132,8 +132,12 @@
     <p><code>variable_importance</code> measures importance of variables based on specified methods.</p>
     </div>
 
-    <pre class="usage"><span class='fu'>variable_importance</span>(<span class='no'>sample</span>, <span class='no'>variables</span>,
-  <span class='kw'>operation</span> <span class='kw'>=</span> <span class='st'>"replicate_correlation"</span>, <span class='no'>...</span>)</pre>
+    <pre class="usage"><span class='fu'>variable_importance</span>(
+  <span class='no'>sample</span>,
+  <span class='no'>variables</span>,
+  <span class='kw'>operation</span> <span class='kw'>=</span> <span class='st'>"replicate_correlation"</span>,
+  <span class='no'>...</span>
+)</pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
@@ -205,7 +209,7 @@
   <span class='kw'>cores</span> <span class='kw'>=</span> <span class='fl'>1</span>
 )</div><div class='output co'>#&gt; </span><span style='color: #555555;'># A tibble: 3 x 4</span><span>
 #&gt;   variable median   min   max
-#&gt;   </span><span style='color: #555555;font-style: italic;'>&lt;chr&gt;</span><span>     </span><span style='color: #555555;font-style: italic;'>&lt;dbl&gt;</span><span> </span><span style='color: #555555;font-style: italic;'>&lt;dbl&gt;</span><span> </span><span style='color: #555555;font-style: italic;'>&lt;dbl&gt;</span><span>
+#&gt; </span><span style='color: #555555;'>*</span><span> </span><span style='color: #555555;font-style: italic;'>&lt;chr&gt;</span><span>     </span><span style='color: #555555;font-style: italic;'>&lt;dbl&gt;</span><span> </span><span style='color: #555555;font-style: italic;'>&lt;dbl&gt;</span><span> </span><span style='color: #555555;font-style: italic;'>&lt;dbl&gt;</span><span>
 #&gt; </span><span style='color: #555555;'>1</span><span> x         1.00  1.00  1.00 
 #&gt; </span><span style='color: #555555;'>2</span><span> y         0.996 0.993 0.999
 #&gt; </span><span style='color: #555555;'>3</span><span> z         0.627 0.290 0.964</div></span></pre>
@@ -224,7 +228,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.0.</p>
 </div>
 
       </footer>

--- a/docs/reference/variable_select.html
+++ b/docs/reference/variable_select.html
@@ -132,8 +132,13 @@
     <p><code>variable_select</code> selects observation variables based on the specified variable selection method.</p>
     </div>
 
-    <pre class="usage"><span class='fu'>variable_select</span>(<span class='no'>population</span>, <span class='no'>variables</span>, <span class='kw'>sample</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
-  <span class='kw'>operation</span> <span class='kw'>=</span> <span class='st'>"variance_threshold"</span>, <span class='no'>...</span>)</pre>
+    <pre class="usage"><span class='fu'>variable_select</span>(
+  <span class='no'>population</span>,
+  <span class='no'>variables</span>,
+  <span class='kw'>sample</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
+  <span class='kw'>operation</span> <span class='kw'>=</span> <span class='st'>"variance_threshold"</span>,
+  <span class='no'>...</span>
+)</pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
@@ -223,7 +228,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.0.</p>
 </div>
 
       </footer>

--- a/docs/reference/variance_threshold.html
+++ b/docs/reference/variance_threshold.html
@@ -177,7 +177,7 @@ the default values for <code>freqCut</code> and <code>uniqueCut</code>.</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.0.</p>
 </div>
 
       </footer>

--- a/docs/reference/whiten.html
+++ b/docs/reference/whiten.html
@@ -188,7 +188,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.0.</p>
 </div>
 
       </footer>

--- a/man/aggregate.Rd
+++ b/man/aggregate.Rd
@@ -4,8 +4,14 @@
 \alias{aggregate}
 \title{Aggregate data based on given grouping.}
 \usage{
-aggregate(population, variables, strata, operation = "mean",
-  univariate = TRUE, ...)
+aggregate(
+  population,
+  variables,
+  strata,
+  operation = "mean",
+  univariate = TRUE,
+  ...
+)
 }
 \arguments{
 \item{population}{tbl with grouping (metadata) and observation variables.}

--- a/man/correlation_threshold.Rd
+++ b/man/correlation_threshold.Rd
@@ -4,8 +4,7 @@
 \alias{correlation_threshold}
 \title{Remove redundant variables.}
 \usage{
-correlation_threshold(variables, sample, cutoff = 0.9,
-  method = "pearson")
+correlation_threshold(variables, sample, cutoff = 0.9, method = "pearson")
 }
 \arguments{
 \item{variables}{character vector specifying observation variables.}

--- a/man/drop_na_rows.Rd
+++ b/man/drop_na_rows.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/drop_na_rows.R
 \name{drop_na_rows}
 \alias{drop_na_rows}
-\title{Drop rows that are \code{NA} in all variables.}
+\title{Drop rows that are \code{NA} in all specified variables.}
 \usage{
 drop_na_rows(population, variables)
 }
@@ -12,10 +12,10 @@ drop_na_rows(population, variables)
 \item{variables}{character vector specifying observation variables.}
 }
 \value{
-\code{population} without rows that have \code{NA} in all variables.
+\code{population} without rows that have \code{NA} in all specified variables.
 }
 \description{
-\code{drop_na_rows} drops rows that are \code{NA} in all variables.
+\code{drop_na_rows} drops rows that are \code{NA} in all specified variables.
 }
 \examples{
 population <- tibble::tibble(

--- a/man/normalize.Rd
+++ b/man/normalize.Rd
@@ -4,8 +4,14 @@
 \alias{normalize}
 \title{Normalize observation variables.}
 \usage{
-normalize(population, variables, strata, sample,
-  operation = "standardize", ...)
+normalize(
+  population,
+  variables,
+  strata,
+  sample,
+  operation = "standardize",
+  ...
+)
 }
 \arguments{
 \item{population}{tbl with grouping (metadata) and observation variables.}

--- a/man/replicate_correlation.Rd
+++ b/man/replicate_correlation.Rd
@@ -4,8 +4,15 @@
 \alias{replicate_correlation}
 \title{Measure replicate correlation of variables.}
 \usage{
-replicate_correlation(sample, variables, strata, replicates,
-  replicate_by = NULL, split_by = NULL, cores = NULL)
+replicate_correlation(
+  sample,
+  variables,
+  strata,
+  replicates,
+  replicate_by = NULL,
+  split_by = NULL,
+  cores = NULL
+)
 }
 \arguments{
 \item{sample}{tbl containing sample used to estimate parameters.}

--- a/man/variable_importance.Rd
+++ b/man/variable_importance.Rd
@@ -4,8 +4,12 @@
 \alias{variable_importance}
 \title{Measure variable importance.}
 \usage{
-variable_importance(sample, variables,
-  operation = "replicate_correlation", ...)
+variable_importance(
+  sample,
+  variables,
+  operation = "replicate_correlation",
+  ...
+)
 }
 \arguments{
 \item{sample}{tbl containing sample used to estimate parameters.}

--- a/man/variable_select.Rd
+++ b/man/variable_select.Rd
@@ -4,8 +4,13 @@
 \alias{variable_select}
 \title{Select observation variables.}
 \usage{
-variable_select(population, variables, sample = NULL,
-  operation = "variance_threshold", ...)
+variable_select(
+  population,
+  variables,
+  sample = NULL,
+  operation = "variance_threshold",
+  ...
+)
 }
 \arguments{
 \item{population}{tbl with grouping (metadata) and observation variables.}

--- a/tests/testthat/test-aggregate.R
+++ b/tests/testthat/test-aggregate.R
@@ -27,7 +27,8 @@ test_that("`aggregate` aggregates data", {
       dplyr::summarise_at(
         .funs = ~ MEDIAN(.),
         .vars = c("x", "y")
-      )
+      ) %>%
+      dplyr::collect()
   )
 
   expect_equal(
@@ -43,7 +44,8 @@ test_that("`aggregate` aggregates data", {
       dplyr::summarise_at(
         .funs = ~ MEDIAN(.),
         .vars = c("x", "y")
-      )
+      ) %>%
+      dplyr::collect()
   )
 
   expect_equal(
@@ -59,7 +61,8 @@ test_that("`aggregate` aggregates data", {
       dplyr::summarise_at(
         .funs = c(~ mean(., na.rm = T), ~ sd(., na.rm = T)),
         .vars = c("x", "y")
-      )
+      ) %>%
+      dplyr::collect()
   )
 
   cov_a <-

--- a/tests/testthat/test-cytominer.R
+++ b/tests/testthat/test-cytominer.R
@@ -11,7 +11,7 @@ test_that("cytominer can process dataset with a normalized schema", {
       package = "cytominer"
     )
 
-  db <-  DBI::dbConnect(RSQLite::SQLite(), fixture)
+  db <- DBI::dbConnect(RSQLite::SQLite(), fixture)
 
   ext_metadata <-
     readr::read_csv(system.file(

--- a/tests/testthat/test-cytominer.R
+++ b/tests/testthat/test-cytominer.R
@@ -11,7 +11,7 @@ test_that("cytominer can process dataset with a normalized schema", {
       package = "cytominer"
     )
 
-  db <- dplyr::src_sqlite(path = fixture)
+  db <-  DBI::dbConnect(RSQLite::SQLite(), fixture)
 
   ext_metadata <-
     readr::read_csv(system.file(
@@ -194,6 +194,8 @@ test_that("cytominer can process dataset with a normalized schema", {
     ),
     paste0("undefined operation 'dummy'")
   )
+
+  DBI::dbDisconnect(db)
 })
 
 test_that("cytominer can process dataset with a CellProfiler schema", {

--- a/tests/testthat/test-drop_na_rows.R
+++ b/tests/testthat/test-drop_na_rows.R
@@ -12,10 +12,16 @@ test_that("`drop_na_rows` removes rows have only NAs", {
   data %<>% dplyr::filter(x != 1)
 
   drop_na_rows_data_frame <- function(population, variables) {
+    # TODO: this is a reimplementation of the code within `drop_na_rows`
+    # so this method should be probably be replaced with a different
+    # implementation
     population %>%
-      tidyr::gather(key, value, variables) %>%
+      tibble::rowid_to_column() %>%
+      tidyr::pivot_longer(variables) %>%
       dplyr::filter(!is.na(value)) %>%
-      tidyr::spread(key, value)
+      tidyr::pivot_wider(names_from = "name", values_from = "value") %>%
+      dplyr::select(-rowid) %>%
+      dplyr::select(names(population))
   }
 
   expect_equal(

--- a/tests/testthat/test-extract_subpopulations.R
+++ b/tests/testthat/test-extract_subpopulations.R
@@ -49,8 +49,7 @@ test_that(
     # find nearest cluster center and distance to it
     cluster_assign <- function(data, centers, variables, k) {
       dist_to_clusters <-
-        cross_dist(data[, variables], centers) %>%
-        unname()
+        cross_dist(data[, variables], centers)
 
       apply(
         dist_to_clusters, 1,
@@ -61,7 +60,8 @@ test_that(
           )
         }
       ) %>%
-        dplyr::bind_rows()
+        dplyr::bind_rows() %>%
+        dplyr::mutate(cluster_id = unname(cluster_id))
     }
 
     population_clusters <-

--- a/tests/testthat/test-extract_subpopulations.R
+++ b/tests/testthat/test-extract_subpopulations.R
@@ -48,7 +48,9 @@ test_that(
 
     # find nearest cluster center and distance to it
     cluster_assign <- function(data, centers, variables, k) {
-      dist_to_clusters <- cross_dist(data[, variables], centers)
+      dist_to_clusters <-
+        cross_dist(data[, variables], centers) %>%
+        unname()
 
       apply(
         dist_to_clusters, 1,
@@ -88,12 +90,12 @@ test_that(
     # are consistent with the returned cluster centers
     expect_equal(
       subpops$population_clusters[, c("dist_to_cluster", "cluster_id")],
-      as.data.frame(population_clusters)
+      population_clusters
     )
 
     expect_equal(
       subpops$reference_clusters[, c("dist_to_cluster", "cluster_id")],
-      as.data.frame(reference_clusters)
+      reference_clusters
     )
 
     # test whether the summation of cluster proportions is equal to one

--- a/tests/testthat/test-extract_subpopulations.R
+++ b/tests/testthat/test-extract_subpopulations.R
@@ -89,13 +89,17 @@ test_that(
     # test whether the cluster assignment and distance to the clusters
     # are consistent with the returned cluster centers
     expect_equal(
-      subpops$population_clusters[, c("dist_to_cluster", "cluster_id")],
-      population_clusters
+      subpops$population_clusters[, c("dist_to_cluster", "cluster_id")] %>%
+        as.data.frame(),
+      population_clusters %>%
+        as.data.frame()
     )
 
     expect_equal(
-      subpops$reference_clusters[, c("dist_to_cluster", "cluster_id")],
-      reference_clusters
+      subpops$reference_clusters[, c("dist_to_cluster", "cluster_id")] %>%
+        as.data.frame(),
+      reference_clusters %>%
+        as.data.frame()
     )
 
     # test whether the summation of cluster proportions is equal to one

--- a/tests/testthat/test-generalized_log.R
+++ b/tests/testthat/test-generalized_log.R
@@ -16,7 +16,8 @@ test_that("`generalized_log` generalized_logs data", {
     generalized_log(
       population = data,
       variables = c("x", "y")
-    ) %>% dplyr::collect(),
+    ) %>% dplyr::collect() %>%
+      as.data.frame(),
     glog(data %>% dplyr::collect())
   )
 


### PR DESCRIPTION
Updates for `dplyr 1.0.0` compatibility
- `src_sqlite` is deprecated
- [new](https://www.tidyverse.org/blog/2020/04/dplyr-1-0-0-package-dev/) behavior of `all.equal`. All failures were related to this.
- other code cleanup